### PR TITLE
fix: Migrate to .NET 9.0 and fix Azure deployment issues

### DIFF
--- a/.github/workflows/main_kaivnitboilerplate.yml
+++ b/.github/workflows/main_kaivnitboilerplate.yml
@@ -20,20 +20,16 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.x'
+          dotnet-version: '9.x'
 
       - name: Restore
         run: dotnet restore src/KaivnitBoilerplate.Presentation/KaivnitBoilerplate.Presentation.csproj
 
-      - name: Publish self-contained (win-x64)
+      - name: Publish framework-dependent
         run: >
           dotnet publish src/KaivnitBoilerplate.Presentation/KaivnitBoilerplate.Presentation.csproj
           -c Release
-          -r win-x64
-          --self-contained true
-          -p:PublishSingleFile=true
-          -p:PublishTrimmed=false
-          -p:UseAppHost=true
+          --self-contained false
           -o "${{ github.workspace }}/publish"
 
       - name: Archive package (no nested folder)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KaivnitBoilerplate
 
 ## Overview
-A boilerplate project built with Clean Architecture and Domain-Driven Design (DDD), using .NET 10.0 and ASP.NET Core Razor Pages.
+A boilerplate project built with Clean Architecture and Domain-Driven Design (DDD), using .NET 9.0 and ASP.NET Core Razor Pages.
 
 ## Project Structure
 
@@ -29,17 +29,17 @@ KaivnitBoilerplate/
 
 #### 1. **Domain Layer** (`KaivnitBoilerplate.Domain`)
 - **Purpose**: Contains entities, value objects, domain services and core business rules
-- **Characteristics**: 
+- **Characteristics**:
   - No dependencies on any other layers
   - Contains pure business logic
-  - Framework: .NET 10.0 (Class Library)
+  - Framework: .NET 9.0 (Class Library)
 
 #### 2. **Application Layer** (`KaivnitBoilerplate.Application`)
 - **Purpose**: Contains use cases, application services and interfaces
 - **Characteristics**:
   - Depends on Domain Layer
   - Defines interfaces for Infrastructure Layer
-  - Framework: .NET 10.0 (Class Library)
+  - Framework: .NET 9.0 (Class Library)
   - References: Domain Layer
 
 #### 3. **Infrastructure Layer** (`KaivnitBoilerplate.Infrastructure`)
@@ -47,7 +47,7 @@ KaivnitBoilerplate/
 - **Characteristics**:
   - Contains data access, external API calls, file system operations
   - Depends on Application and Domain Layer
-  - Framework: .NET 10.0 (Class Library)
+  - Framework: .NET 9.0 (Class Library)
   - References: Application Layer, Domain Layer
 
 #### 4. **Presentation Layer** (`KaivnitBoilerplate.Presentation`)
@@ -55,7 +55,7 @@ KaivnitBoilerplate/
 - **Characteristics**:
   - Uses ASP.NET Core Razor Pages
   - Depends on Application and Infrastructure Layer
-  - Framework: .NET 10.0 (Web Application)
+  - Framework: .NET 9.0 (Web Application)
   - References: Application Layer, Infrastructure Layer
 
 

--- a/src/KaivnitBoilerplate.Application/KaivnitBoilerplate.Application.csproj
+++ b/src/KaivnitBoilerplate.Application/KaivnitBoilerplate.Application.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KaivnitBoilerplate.Domain/KaivnitBoilerplate.Domain.csproj
+++ b/src/KaivnitBoilerplate.Domain/KaivnitBoilerplate.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/KaivnitBoilerplate.Infrastructure/KaivnitBoilerplate.Infrastructure.csproj
+++ b/src/KaivnitBoilerplate.Infrastructure/KaivnitBoilerplate.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/KaivnitBoilerplate.Presentation/KaivnitBoilerplate.Presentation.csproj
+++ b/src/KaivnitBoilerplate.Presentation/KaivnitBoilerplate.Presentation.csproj
@@ -1,23 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-	
-	<!-- Self-contained + Single-file -->
-    <SelfContained>true</SelfContained>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <PublishSingleFile>true</PublishSingleFile>
-    <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
-    <PublishTrimmed>false</PublishTrimmed>
-	
-	<!-- Important for .exe (self-contained) -->
-	<UseAppHost>true</UseAppHost>
-	
+
+	<!-- Framework-dependent deployment for better Azure compatibility -->
+    <SelfContained>false</SelfContained>
+
 	<!-- Hosting/IIS - To publish/transform standard web.config for ANCM -->
 	<IsTransformWebConfigDisabled>false</IsTransformWebConfigDisabled>
-    <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
 
     <!-- Useful options -->
     <InvariantGlobalization>false</InvariantGlobalization>


### PR DESCRIPTION
- Whitelist Azure headers in SecurityRequestHeaderMiddleware
  - Downgrade from .NET 10 RC to .NET 9.0 for production stability
  - Switch to framework-dependent deployment for better Azure compatibility
  - Enable InProcess hosting model for IIS/Azure
  - Update CI/CD pipeline to use .NET 9.0