### PR TITLE
fix: Add detailed logging and disable validation for Azure debugging

### DIFF
--- a/src/KaivnitBoilerplate.Presentation/appsettings.json
+++ b/src/KaivnitBoilerplate.Presentation/appsettings.json
@@ -34,9 +34,9 @@
     "UpgradeInsecureRequests": "true",
     "PublicCacheMaxAgeSeconds": "3600",
     "EnableRequestTracking": "true",
-    "BlockDangerousRequestHeaders": "true",
-    "ValidateRequestHeaderValues": "true",
-    "MaxRequestHeaderSize": "8192",
-    "MaxTotalRequestHeaderSize": "32768"
+    "BlockDangerousRequestHeaders": "false",
+    "ValidateRequestHeaderValues": "false",
+    "MaxRequestHeaderSize": "32768",
+    "MaxTotalRequestHeaderSize": "65536"
   }
 }


### PR DESCRIPTION
- Add comprehensive header logging in SecurityRequestHeaderMiddleware
  - Temporarily disable validation to allow all requests
  - Log all incoming headers for debugging Azure infrastructure
  - Increase header size limits