### PR TITLE
feat: Upgrade to .NET 10.0 and fix Azure deployment

### DIFF
--- a/.github/workflows/main_kaivnitboilerplate.yml
+++ b/.github/workflows/main_kaivnitboilerplate.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.x'
+          dotnet-version: '10.x'
 
       - name: Restore
         run: dotnet restore src/KaivnitBoilerplate.Presentation/KaivnitBoilerplate.Presentation.csproj

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KaivnitBoilerplate
 
 ## Overview
-A boilerplate project built with Clean Architecture and Domain-Driven Design (DDD), using .NET 9.0 and ASP.NET Core Razor Pages.
+A boilerplate project built with Clean Architecture and Domain-Driven Design (DDD), using .NET 10.0 and ASP.NET Core Razor Pages.
 
 ## Project Structure
 
@@ -32,14 +32,14 @@ KaivnitBoilerplate/
 - **Characteristics**:
   - No dependencies on any other layers
   - Contains pure business logic
-  - Framework: .NET 9.0 (Class Library)
+  - Framework: .NET 10.0 (Class Library)
 
 #### 2. **Application Layer** (`KaivnitBoilerplate.Application`)
 - **Purpose**: Contains use cases, application services and interfaces
 - **Characteristics**:
   - Depends on Domain Layer
   - Defines interfaces for Infrastructure Layer
-  - Framework: .NET 9.0 (Class Library)
+  - Framework: .NET 10.0 (Class Library)
   - References: Domain Layer
 
 #### 3. **Infrastructure Layer** (`KaivnitBoilerplate.Infrastructure`)
@@ -47,7 +47,7 @@ KaivnitBoilerplate/
 - **Characteristics**:
   - Contains data access, external API calls, file system operations
   - Depends on Application and Domain Layer
-  - Framework: .NET 9.0 (Class Library)
+  - Framework: .NET 10.0 (Class Library)
   - References: Application Layer, Domain Layer
 
 #### 4. **Presentation Layer** (`KaivnitBoilerplate.Presentation`)
@@ -55,7 +55,7 @@ KaivnitBoilerplate/
 - **Characteristics**:
   - Uses ASP.NET Core Razor Pages
   - Depends on Application and Infrastructure Layer
-  - Framework: .NET 9.0 (Web Application)
+  - Framework: .NET 10.0 (Web Application)
   - References: Application Layer, Infrastructure Layer
 
 

--- a/src/KaivnitBoilerplate.Application/KaivnitBoilerplate.Application.csproj
+++ b/src/KaivnitBoilerplate.Application/KaivnitBoilerplate.Application.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0-rc.1.25103.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/KaivnitBoilerplate.Domain/KaivnitBoilerplate.Domain.csproj
+++ b/src/KaivnitBoilerplate.Domain/KaivnitBoilerplate.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/KaivnitBoilerplate.Infrastructure/Installers/Middlewares/SecurityRequestHeaderMiddlewareInstaller.cs
+++ b/src/KaivnitBoilerplate.Infrastructure/Installers/Middlewares/SecurityRequestHeaderMiddlewareInstaller.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 
 namespace KaivnitBoilerplate.Infrastructure.Installers.Middlewares;
 
-[MiddlewareOrder(5)] // Run early in pipeline, but after exception handler
+[MiddlewareOrder(5)]
 public sealed class SecurityRequestHeaderMiddlewareInstaller : IMiddlewareInstaller
 {
     public void InstallMiddleware(IApplicationBuilder app, IWebHostEnvironment env)

--- a/src/KaivnitBoilerplate.Infrastructure/KaivnitBoilerplate.Infrastructure.csproj
+++ b/src/KaivnitBoilerplate.Infrastructure/KaivnitBoilerplate.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/KaivnitBoilerplate.Presentation/KaivnitBoilerplate.Presentation.csproj
+++ b/src/KaivnitBoilerplate.Presentation/KaivnitBoilerplate.Presentation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 


### PR DESCRIPTION
- Upgrade all projects to .NET 10.0
- Add Azure header whitelisting in SecurityRequestHeaderMiddleware
- Add detailed logging for debugging Azure requests
- Temporarily disable strict validation for initial deployment
- Switch to framework-dependent deployment for Azure compatibility
- Update CI/CD pipeline to .NET 10.x